### PR TITLE
Update korean_dubeolsik_combineinitials.yaml

Add long-press selection of shifted hangul letters for dubeolsik (similar to how is done in Gboard/Samsung Keyboard/Heliboard/others).

### DIFF
--- a/Korean/korean_dubeolsik.yaml
+++ b/Korean/korean_dubeolsik.yaml
@@ -5,15 +5,15 @@ combiners:
 attributes: {shiftable: false}
 rows:
   - letters:
-    - {type: case, normal: ["ㅂ"], shiftedManually: ["ㅃ"]}
-    - {type: case, normal: ["ㅈ"], shiftedManually: ["ㅉ"]}
-    - {type: case, normal: ["ㄷ"], shiftedManually: ["ㄸ"]}
-    - {type: case, normal: ["ㄱ"], shiftedManually: ["ㄲ"]}
-    - {type: case, normal: ["ㅅ"], shiftedManually: ["ㅆ"]}
+    - {type: case, normal: ["ㅂ", "ㅃ"], shiftedManually: ["ㅃ"]}
+    - {type: case, normal: ["ㅈ", "ㅉ"], shiftedManually: ["ㅉ"]}
+    - {type: case, normal: ["ㄷ", "ㄸ"], shiftedManually: ["ㄸ"]}
+    - {type: case, normal: ["ㄱ", "ㄲ"], shiftedManually: ["ㄲ"]}
+    - {type: case, normal: ["ㅅ", "ㅆ"], shiftedManually: ["ㅆ"]}
     - ㅛ
     - ㅕ
     - ㅑ
-    - {type: case, normal: ["ㅐ"], shiftedManually: ["ㅒ"]}
-    - {type: case, normal: ["ㅔ"], shiftedManually: ["ㅖ"]}
+    - {type: case, normal: ["ㅐ", "ㅒ"], shiftedManually: ["ㅒ"]}
+    - {type: case, normal: ["ㅔ", "ㅖ"], shiftedManually: ["ㅖ"]}
   - letters: ㅁ ㄴ ㅇ ㄹ ㅎ ㅗ ㅓ ㅏ ㅣ
   - letters: ㅋ ㅌ ㅊ ㅍ ㅠ ㅜ ㅡ

--- a/Korean/korean_dubeolsik_combineinitials.yaml
+++ b/Korean/korean_dubeolsik_combineinitials.yaml
@@ -5,15 +5,15 @@ combiners:
 attributes: {shiftable: false}
 rows:
   - letters:
-    - {type: case, normal: ["ㅂ"], shiftedManually: ["ㅃ"]}
-    - {type: case, normal: ["ㅈ"], shiftedManually: ["ㅉ"]}
-    - {type: case, normal: ["ㄷ"], shiftedManually: ["ㄸ"]}
-    - {type: case, normal: ["ㄱ"], shiftedManually: ["ㄲ"]}
-    - {type: case, normal: ["ㅅ"], shiftedManually: ["ㅆ"]}
+    - {type: case, normal: ["ㅂ", "ㅃ"], shiftedManually: ["ㅃ"]}
+    - {type: case, normal: ["ㅈ", "ㅉ"], shiftedManually: ["ㅉ"]}
+    - {type: case, normal: ["ㄷ", "ㄸ"], shiftedManually: ["ㄸ"]}
+    - {type: case, normal: ["ㄱ", "ㄲ"], shiftedManually: ["ㄲ"]}
+    - {type: case, normal: ["ㅅ", "ㅆ"], shiftedManually: ["ㅆ"]}
     - ㅛ
     - ㅕ
     - ㅑ
-    - {type: case, normal: ["ㅐ"], shiftedManually: ["ㅒ"]}
-    - {type: case, normal: ["ㅔ"], shiftedManually: ["ㅖ"]}
+    - {type: case, normal: ["ㅐ", "ㅒ"], shiftedManually: ["ㅒ"]}
+    - {type: case, normal: ["ㅔ", "ㅖ"], shiftedManually: ["ㅖ"]}
   - letters: ㅁ ㄴ ㅇ ㄹ ㅎ ㅗ ㅓ ㅏ ㅣ
   - letters: ㅋ ㅌ ㅊ ㅍ ㅠ ㅜ ㅡ


### PR DESCRIPTION
Currently, in the dubeolsik (두벌식) layouts, one can only select the "shifted" hangul characters (such as ㄱ vs ㄲ or ㅐvsㅒ) by manually pressing shift or use the variant with double-press (which is limited to consonants.

This adds the shifted characters into the long-press options for dubeolsik, so that now the characters can be selected using both/either of pressing the shift key manually or through long pressing the key.

This isn't a necessary change, but it could make for an easier transition from other common keyboard apps with Korean-dubeolsik layouts that have the feature; such as Gboard, Samsung Keyboard, Heliboard, SwiftKey).